### PR TITLE
Change W1ex19 test to better reflect the exercise text

### DIFF
--- a/W1Test.hs
+++ b/W1Test.hs
@@ -190,5 +190,5 @@ prop_ex18_isPrime =
 
 prop_ex19_nextPrime =
   forAll (elements [0..max]) $ \n ->
-  nextPrime n === head (dropWhile (<n) primes)
+  nextPrime n === head (dropWhile (<=n) primes)
   where max = 100


### PR DESCRIPTION
The exercise reads:

> implement a function nextPrime that returns the first prime
> number that comes after the given number. Use the function isPrime
> you just defined.

Since it says "first prime number that comes after the given number", I take that to mean that if the number given is prime, it should not return that number but the next prime number. When the test here is (<n), my implementation breaks for (nextPrime 79). Since 79 is prime, the function returns 83, the next prime number, but the test claims that 79 should be returned.
