### PR TITLE
Fix #15: Incorrect definition of `primes`

### DIFF
--- a/W1Test.hs
+++ b/W1Test.hs
@@ -170,7 +170,12 @@ ex16_pyramid =
   f (pyramid n) === ([0..n] ++ [n-1,n-2..0])
   where f xs = map read $ split ',' xs
 
-primes = nubBy (\x y -> mod x y == 0) [2..]
+primes = 2 : filter isPrime' [3, 5 ..]
+  where
+    isPrime' n
+        | n < 2     = False
+        | otherwise = all (\p -> n `mod` p /= 0) $
+                          takeWhile (\p -> p ^ 2 <= n) primes
 
 ex17_smallestDivisor_prime = do
   forAll (elements $ take 12 primes) $ \p ->


### PR DESCRIPTION
The definition of 'primes' in `W1Test.hs` was incorrect. As a result,
tests for problems 17 through 19 would fail, even on correct solutions.
Replacing the incorrect definition by a correct one solved the problem.