### PR TITLE
Week six mismatched operator

### DIFF
--- a/templ/W6B.hs
+++ b/templ/W6B.hs
@@ -193,7 +193,7 @@ multiplyLog :: Int -> Int -> Logger Int
 multiplyLog a b = do
   msg ("first arg is " ++ show a)
   msg ("second arg is " ++ show b)
-  let ret = a + b
+  let ret = a * b
   msg ("returning product " ++ show ret)
   return ret
 
@@ -574,7 +574,7 @@ f2 acc x = undefined
 --   MkResult 1 >> Failure "boom" >> MkResult 2
 --     ==> Failure "boom"
 --   MkResult 1 >> NoResult >> Failure "not reached"
---     ==> NoResult 
+--     ==> NoResult�
 --   MkResult 1 >>= (\x -> MkResult (x+1))
 --     ==> MkResult 2
 


### PR DESCRIPTION
In exercise 4 `*` and `+` operators were mismatched leading to rather confusing outputs.